### PR TITLE
Make sudo optional if user is already root

### DIFF
--- a/build-yasm.sh
+++ b/build-yasm.sh
@@ -5,6 +5,7 @@ tar xzvf yasm-1.2.0.tar.gz
 pushd yasm-1.2.0
 ./configure
 make
-sudo checkinstall --pkgname=yasm --pkgversion="1.2.0" --backup=no --deldoc=yes --default
+[ "$(id -u)" != 0 ] && sudo=sudo || sudo=
+$sudo checkinstall --pkgname=yasm --pkgversion="1.2.0" --backup=no --deldoc=yes --default
 popd
 rm yasm-1.2.0.tar.gz


### PR DESCRIPTION
This makes the installation of `sudo` package optional when user is already root. When packaging Docker image for instance, it prevents having to install it. 