### PR TITLE
Use https depot URL instead of ssh URL

### DIFF
--- a/build-x264.sh
+++ b/build-x264.sh
@@ -12,7 +12,7 @@ if [ -d "x264" ]; then
     fi
     popd
 else
-    git clone git://git.videolan.org/x264
+    git clone https://git.videolan.org/git/x264.git
 fi
 
 pushd x264


### PR DESCRIPTION
Since some organizations block ssh outgoing connection, using https by default is better.